### PR TITLE
Fix TypeError when instance lists are empty

### DIFF
--- a/ec2-check-reserved-instances.py
+++ b/ec2-check-reserved-instances.py
@@ -81,7 +81,7 @@ else:
 	for unreserved_instance in unreserved_instances:
 		print "Instance not reserved:\t(%s)\t%s\t%s" % ( unreserved_instances[ unreserved_instance ], unreserved_instance[0], unreserved_instance[1] )
 
-qty_running_instances = reduce( lambda x, y: x+y, running_instances.values() )
-qty_reserved_instances = reduce( lambda x, y: x+y, reserved_instances.values() )
+qty_running_instances = reduce( lambda x, y: x+y, running_instances.values(), 0 )
+qty_reserved_instances = reduce( lambda x, y: x+y, reserved_instances.values(), 0 )
 
 print "\n(%s) running on-demand instances\n(%s) reservations" % ( qty_running_instances, qty_reserved_instances )


### PR DESCRIPTION
Fixes:

$ ./ec2-check-reserved-instances.py
Congratulations, you have no unused reservations

Congratulations, you have no unreserved instances
Traceback (most recent call last):
  File "./ec2-check-reserved-instances.py", line 84, in <module>
    qty_running_instances = reduce( lambda x, y: x+y, running_instances.values() )
TypeError: reduce() of empty sequence with no initial value
